### PR TITLE
fix(types): use default values in CdoGriddes

### DIFF
--- a/src/geoglue/types.py
+++ b/src/geoglue/types.py
@@ -55,12 +55,12 @@ class CdoGriddes:
     ysize: int
     xname: str
     yname: str
-    ylongname: str
-    yunits: str
     xfirst: float
     xinc: float
     yfirst: float
     yinc: float
+    ylongname: str = "latitude"
+    yunits: str = "degrees_north"
     xlongname: str = "longitude"
     xunits: str = "degrees_east"
 

--- a/tests/test_griddes.py
+++ b/tests/test_griddes.py
@@ -11,12 +11,12 @@ xsize     = 879
 ysize     = 1781
 xname     = longitude
 yname     = latitude
-ylongname = "latitude"
-yunits    = "degrees_north"
 xfirst    = 102.14874960275003
 xinc      = 0.0083333333
 yfirst    = 8.557916831327146
 yinc      = 0.0083333333
+ylongname = "latitude"
+yunits    = "degrees_north"
 xlongname = "longitude"
 xunits    = "degrees_east"
   """.strip()


### PR DESCRIPTION
This should fix an issue when there is no ylongname or yunits
detected in the cdo griddes output.
