### PR TITLE
remove: get_worldpop_1km()

### DIFF
--- a/src/geoglue/resample.py
+++ b/src/geoglue/resample.py
@@ -101,8 +101,9 @@ def resampled_dataset(
     Example
     -------
     >>> from geoglue.resample import resampled_dataset
-    >>> from geoglue.region import get_worldpop_1km
-    >>> with resampled_dataset("remapbil", "somefile.nc", get_worldpop_1km('ABC', 2020)) as ds:
+    >>> from geoglue import MemoryRaster
+    >>> pop = MemoryRaster.read("VNM_ppp_2000_1km_Aggregated_UNadj.tif")
+    >>> with resampled_dataset("remapbil", "somefile.nc", pop) as ds:
     ...     print(ds)
     """
     if isinstance(data, xr.Dataset):

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -5,11 +5,11 @@ import pytest
 import numpy as np
 from unittest.mock import patch
 
+from geoglue.memoryraster import MemoryRaster
 from geoglue.region import (
     gadm,
     geoboundaries,
     get_timezone,
-    get_worldpop_1km,
     Region,
 )
 from geoglue.types import Bbox
@@ -97,15 +97,8 @@ def test_invalid_admin_raises_error():
 
 @pytest.mark.parametrize("year,population", [(2000, 79910432), (2020, 97338600)])
 def test_worldpop_1km(year, population):
-    assert int(get_worldpop_1km("VNM", year, data_path=DATA_PATH).sum()) == population
-
-
-def test_population_invalid_year():
-    err = "Worldpop population data is only available from 2000-2020"
-    with pytest.raises(ValueError, match=err):
-        get_worldpop_1km("VNM", 1999)
-    with pytest.raises(ValueError, match=err):
-        get_worldpop_1km("VNM", 2040)
+    rast = MemoryRaster.read(f"data/VNM/worldpop/vnm_ppp_{year}_1km_Aggregated_UNadj.tif")
+    assert int(rast.sum()) == population
 
 
 def test_read_shapefiles(region_geoboundaries):

--- a/tests/test_zonal_stats.py
+++ b/tests/test_zonal_stats.py
@@ -3,8 +3,9 @@ from pathlib import Path
 import pytest
 import xarray as xr
 from geoglue.zonal_stats import zonal_stats, zonal_stats_xarray
-from geoglue.region import geoboundaries, get_worldpop_1km
+from geoglue.region import geoboundaries
 from geoglue.resample import resample
+from geoglue.memoryraster import MemoryRaster
 from geoglue.util import sort_lonlat, find_unique_time_coord
 
 DATA_PATH = Path("data")
@@ -26,7 +27,7 @@ def vnm_geoboundaries_admin2():
 
 @pytest.fixture(scope="module")
 def vnm_pop():
-    return get_worldpop_1km("VNM", 2020, data_path=DATA_PATH)
+    return MemoryRaster.read("data/VNM/worldpop/vnm_ppp_2020_1km_Aggregated_UNadj.tif")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
BREAKING CHANGE: remove get_worldpop_1km() from geoglue, this is
domain specific code that belongs better in downstream applications
such as DART-Pipeline.  There are also several variations of
Worldpop data (unconstrained, constrained, unconstrained UN
adjusted), out of which this function arbitrarily chooses one.
