### PR TITLE
Add `Bbox.coverage_fraction()`

### DIFF
--- a/src/geoglue/types.py
+++ b/src/geoglue/types.py
@@ -80,7 +80,7 @@ class Bbox(NamedTuple):
 
     def coverage_fraction(self, other: Bbox) -> float:
         if self.__ge__(other):
-            return 100
+            return 1.0
         else:
             self.overlap_fraction(other)
 

--- a/src/geoglue/types.py
+++ b/src/geoglue/types.py
@@ -78,6 +78,12 @@ class Bbox(NamedTuple):
             self.geodetic_area_km2, other.geodetic_area_km2
         )
 
+    def coverage_fraction(self, other: Bbox) -> float:
+        if self.__ge__(other):
+            return 100
+        else:
+            self.overlap_fraction(other)
+
     def __str__(self) -> str:
         return f"{self.minx},{self.miny},{self.maxx},{self.maxy}"
 


### PR DESCRIPTION
Add new method for `Bbox` called `coverage_fraction()` which gives the fractional value of how much `self` bbox **covers** `other` bbox

Under the hood, it's just `overlap_fraction()` but with a conditional check if `other` is fully within `self`