### PR TITLE
config: support iso3_lower in templates

### DIFF
--- a/src/geoglue/config.py
+++ b/src/geoglue/config.py
@@ -59,8 +59,20 @@ def _apply_template(s: string.Template, mapping: dict) -> str:
     """
     Expand $var like templates from string `s` using mapping
     """
+    if "iso3" in mapping:
+        mapping["iso3"] = mapping["iso3"].upper()
+        mapping["iso3_lower"] = mapping["iso3"].lower()
     s = string.Template(os.path.expanduser(s.template))
     return s.substitute(mapping)
+
+
+def _check_vars_match(input_vars: set[str], output_vars: set[str]):
+    if "iso3_lower" in input_vars:
+        input_vars = (input_vars - {"iso3_lower"}) | {"iso3"}
+    if "iso3_lower" in output_vars:
+        output_vars = (output_vars - {"iso3_lower"}) | {"iso3"}
+    if input_vars != output_vars:
+        raise ValueError(f"All variables in input {input_vars} must be in output")
 
 
 @dataclass(frozen=True)
@@ -130,6 +142,9 @@ class CropConfigTemplate:
         region = string.Template(data["region"])
         output = string.Template(data["output"])
         integer_bounds = bool(data["integer_bounds"])
+        input_vars = _get_template_vars(raster) | _get_template_vars(region)
+        output_vars = _get_template_vars(output)
+        _check_vars_match(input_vars, output_vars)
         return CropConfigTemplate(raster, region, output, integer_bounds, split)
 
     @classmethod
@@ -258,10 +273,7 @@ class ZonalStatsTemplate:
             | _get_template_vars(weights)
         )
         output_vars = _get_template_vars(output)
-        if input_vars != output_vars:
-            raise ValueError(
-                "All variables in input {input_vars} must be in output={output.template!r}"
-            )
+        _check_vars_match(input_vars, output_vars)
         if weights and (
             data["operation"] != "area_weighted_sum"
             and not data["operation"].startswith("weighted_")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,12 @@
 import os
 import pytest
 from pathlib import Path
-from geoglue.config import CropConfig, CropConfigTemplate, ZonalStatsTemplate
+from geoglue.config import (
+    CropConfig,
+    CropConfigTemplate,
+    ZonalStatsTemplate,
+    ZonalStatsConfig,
+)
 from geoglue.types import Bbox
 
 
@@ -53,6 +58,33 @@ def weighted_config():
             "weights": "weights $year.tif",
             "resample": "remapbil",
         }
+    )
+
+
+@pytest.fixture(scope="session")
+def iso3_config():
+    return ZonalStatsTemplate.from_dict(
+        {
+            "raster": "data $iso3 $year.nc",
+            "shapefile": "shp/gadm41_${iso3}_1.shp",
+            "shapefile_id": "id",
+            "output": "output $iso3 $year.zonal.nc",
+            "operation": "mean",
+            "weights": "weights $iso3_lower $year.tif",
+            "resample": "remapbil",
+        }
+    )
+
+
+def test_iso3_config(iso3_config):
+    assert iso3_config.fill(year=2015, iso3="sgp") == ZonalStatsConfig(
+        raster=Path("data SGP 2015.nc"),
+        shapefile=Path("shp/gadm41_SGP_1.shp"),
+        shapefile_id="id",
+        output=Path("output SGP 2015.zonal.nc"),
+        operation="weighted_mean",
+        weights=Path("weights sgp 2015.tif"),
+        resample="remapbil",
     )
 
 


### PR DESCRIPTION
This makes it easy to support usecases like Worldpop data where
the filename contains iso3_lower
