### PR TITLE
zonalstats: fix DataArray dimension error with 1-region shapefile

### DIFF
--- a/src/geoglue/zonalstats.py
+++ b/src/geoglue/zonalstats.py
@@ -62,7 +62,11 @@ def _slice_extract_core(
             output="pandas",
         )  # type: ignore
         val = res["weighted_sum"] / res["count"]
-    return val.values.squeeze()
+    ret = val.values.squeeze()
+    if ret.shape == ():  # only one region, must return a array
+        return np.array([ret])
+    else:
+        return ret
 
 
 def zonalstats(


### PR DESCRIPTION
With a 1-region shapefile, da.values.squeeze() returns a scalar
which results in incompatible output dimensions for the region
coordinate that expects a (string) vector

Fixes: #101
