### PR TITLE
rename lat/lon for ncdf when applicable

### DIFF
--- a/src/geoglue/util.py
+++ b/src/geoglue/util.py
@@ -51,6 +51,10 @@ def bbox_from_region(region: str, integer_bounds: bool = False) -> Bbox:
 
 
 def fix_lonlat(ds: X) -> X:
+    if "lat" in ds.dims:
+        ds = ds.rename(lat="latitude")
+    if "lon" in ds.dims:
+        ds = ds.rename(lon="longitude")
     if ds.longitude.max() > 180:
         ds = sort_lonlat(ds)
     set_lonlat_attrs(ds)
@@ -59,10 +63,6 @@ def fix_lonlat(ds: X) -> X:
 
 def read_ncdf(path: str | Path) -> xr.Dataset:
     ds = xr.open_dataset(path)
-    if "lat" in ds.dims:
-        ds = ds.rename(lat="latitude")
-    if "lon" in ds.dims:
-        ds = ds.rename(lon="longitude")
     return ds
 
 


### PR DESCRIPTION
Add a new function to rename lat/lon to latitude/longitude if it exist in the ncdf file. Resolve https://github.com/kraemer-lab/geoglue/issues/107

```python
def read_ncdf(path: str | Path) -> xr.Dataset:
    ds = xr.open_dataset(path)
    if "lat" in ds.dims:
        ds = ds.rename(lat="latitude")
    if "lon" in ds.dims:
        ds = ds.rename(lon="longitude")
    return ds
```